### PR TITLE
Fix static/template path resolution in FastAPI app

### DIFF
--- a/seikai_hack/app.py
+++ b/seikai_hack/app.py
@@ -20,9 +20,14 @@ import models
 
 app = FastAPI(title="LAST MINUTE Exam Prep AI", version="1.0.0")
 
-# Mount static files and templates
-app.mount("/static", StaticFiles(directory="static"), name="static")
-templates = Jinja2Templates(directory="templates")
+# Determine absolute paths for static files and templates
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+app.mount(
+    "/static",
+    StaticFiles(directory=os.path.join(BASE_DIR, "static")),
+    name="static",
+)
+templates = Jinja2Templates(directory=os.path.join(BASE_DIR, "templates"))
 
 # Initialize services
 transcription_service = GeminiService()


### PR DESCRIPTION
## Summary
- resolve static and template directories using absolute paths so app runs from any cwd

## Testing
- `python -m py_compile seikai_hack/app.py`
- `GEMINI_API_KEY=dummy OPENAI_API_KEY=dummy python seikai_hack/app.py` *(fails: ImportError: cannot import name 'genai' from 'google')*

------
https://chatgpt.com/codex/tasks/task_e_689cbe31bb7c832ab826af691d768bd4